### PR TITLE
fix inversion of singular matrix

### DIFF
--- a/src/tjlf_matrix.jl
+++ b/src/tjlf_matrix.jl
@@ -36,7 +36,12 @@ function get_matrix(inputs::InputTJLF{T}, outputGeo::OutputGeometry{T}, outputHe
     get_ave!(inputs, outputGeo, outputHermite, ave, nbasis, ky, ky_index)
 
     if(inputs.VPAR_MODEL==0 && inputs.USE_BPER)
-        ave.bpinv = inv(ave.bp)
+       
+      
+      
+      ave.bpinv = pinv(ave.bp)
+      
+        
         for i = 1:nbasis
             for j = 1:nbasis
                 ave.p0inv[i,j] = 0.0

--- a/src/tjlf_matrix.jl
+++ b/src/tjlf_matrix.jl
@@ -14,6 +14,8 @@ outputs:
 description:
     calculates components used for the eigenmatrix with helper functions that calculate the finite larmor radius integral and hermite basis averages
 """
+
+
 function get_matrix(inputs::InputTJLF{T}, outputGeo::OutputGeometry{T}, outputHermite::OutputHermite{T},
                     ky::T,
                     nbasis::Int, ky_index::Int) where T<:Real
@@ -37,11 +39,12 @@ function get_matrix(inputs::InputTJLF{T}, outputGeo::OutputGeometry{T}, outputHe
 
     if(inputs.VPAR_MODEL==0 && inputs.USE_BPER)
        
-      
-      
-      ave.bpinv = pinv(ave.bp)
-      
-        
+    if isinf(cond(ave.bp))
+     println("Singular matrix, be careful with a solution")
+     ave.bpinv = pinv(ave.bp)
+    else
+     ave.bpinv = inv(ave.bp)
+    end          
         for i = 1:nbasis
             for j = 1:nbasis
                 ave.p0inv[i,j] = 0.0


### PR DESCRIPTION
I believe that the last issue discussed here #36 happens when matrix `ave.bp` is singular (not square and not invertible? ). There is no difference in the solution between `inv` and `pinv` for a normal matrix, but in case of the singular matrix (can be checked by `cond(ave.pb) = Inf`) `pinv` will find a pseudo-inverse of a matrix, while `inv` fails with the error `LinearAlgebra.SingularException(1)`.  

Possible improvements of this PR

- [ ] if `pinv` is much slower than `inv`,  make a condition :
 ```
if cond(ave.pb) = Inf 
    ave.bpinv = pinv(ave.bp)
else
   ave.bpinv = inv(ave.bp)
```
but I don't know how slow is `cond(ave.pb)` check

- [ ] or use `tolerance` parameter for `pinv`
- [ ] only in the testing mode do `cond(ave.pb)` check and print massage if` cond(ave.pb) = Inf`, maybe it will be useful for debugging of finding non-physical cases