### PR TITLE
Keep thread local copy of scalar inputs

### DIFF
--- a/src/tjlf_eigensolver.jl
+++ b/src/tjlf_eigensolver.jl
@@ -2700,7 +2700,7 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
         if inputs.FIND_WIDTH
             error("If FIND_EIGEN false, FIND_WIDTH should also be false")
         end
-        
+
         sigma = 0.0
         if !isnan(inputs.EIGEN_SPECTRUM[ky_index])
             sigma = inputs.EIGEN_SPECTRUM[ky_index]
@@ -2708,15 +2708,15 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
         if sigma != 0.0
             Threads.lock(l2)
             try
-                λ, v = eigs(sparse(amat),sparse(bmat),nev=inputs.NMODES,which=:LR,sigma=sigma,maxiter=50)
-                Threads.unlock(l2)
+                λ, v = eigs(sparse(amat), sparse(bmat), nev=inputs.NMODES, which=:LR, sigma=sigma, maxiter=50)
                 return λ, v, NaN, NaN
-            catch
-                @warn "eigs() can't find eigen for ky = $(inputs.KY_SPECTRUM[ky_index]), using ggev! to find all eigenvalues"
+            catch e
+                @warn "eigs() can't find eigen for ky = $(inputs.KY_SPECTRUM[ky_index]), using ggev! to find all eigenvalues: $(e)"
+            finally
                 Threads.unlock(l2)
             end
         else
-            @warn "no growth rate intial guess given for ky = $(inputs.KY_SPECTRUM[ky_index]), using ggev! to find all eigenvalues"
+            @warn "no growth rate initial guess given for ky = $(inputs.KY_SPECTRUM[ky_index]), using ggev! to find all eigenvalues"
         end
     end
 

--- a/src/tjlf_geometry.jl
+++ b/src/tjlf_geometry.jl
@@ -1043,13 +1043,6 @@ function miller_geo(inputs::InputTJLF{T}; mts::Float64=5.0, ms::Int=128)  where 
     p_prime_s = p_prime_s * B_unit
     q_prime_s = q_prime_s / B_unit
     B_unit_out .= B_unit
-   
-    
-   
-   
-
-
-
 
     return R, Bp, Z, q_prime_s, p_prime_s, B_unit_out, ds, t_s
 end

--- a/src/tjlf_modules.jl
+++ b/src/tjlf_modules.jl
@@ -377,6 +377,15 @@ mutable struct InputTJLF{T<:Real}
     end
 end
 
+function minimal_scalar_copy(inputs::TJLF.InputTJLF{T}) where T<:Real
+    # Create a new instance using the constructor that sets up NS and the number of ky points.
+    local_inputs = TJLF.InputTJLF{T}(inputs.NS, length(inputs.KY_SPECTRUM))
+    # Loop over all fields and assign the value from the original.
+    for f in fieldnames(typeof(inputs))
+        setfield!(local_inputs, f, getfield(inputs, f))
+    end
+    return local_inputs
+end
 
 ##########################################################
 #       Get from tjlf_hermite


### PR DESCRIPTION
Relatively quick fix for thread safety issue https://github.com/ProjectTorreyPines/TJLF.jl/issues/36 related to changing of scalar inputs like `inputs.BPAR` and `inputs.BPER` when using SAT2 and SAT3 EM models