### PR TITLE
GPU Performance Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,37 @@ To run top right, set the InputTJLF SMALL parameter = 0.0, set FIND_EIGEN = True
 See `TJLF/test/test_multithreads` for testing.
 
 ## Critical Threading Setup
-**IMPORTANT**: For proper multithreading performance, you MUST set:
-```bash
-export OMP_NUM_THREADS=1  # In shell environment
+TJLF parallelizes over `ky` with Julia threads, each doing small dense LAPACK
+solves. If BLAS is also multithreaded, those kernels oversubscribe cores (e.g.
+8 Julia threads × 128 BLAS threads) and per-solve time can balloon ~100x.
+
+**TJLF handles this automatically, scoped to its own compute drivers.** It wraps
+the threaded entry points (`run`, `run_tjlf`, and the transport-model loop) with
+`with_blas_threads(1)`, which sets the BLAS thread count to 1 for the duration of
+the call and restores the previous value afterward. This avoids degrading BLAS
+threading for the rest of a host application (e.g. FUSE), so **no manual setup is
+required** for TJLF's own performance.
+
+```julia
+# the scoped helper TJLF uses internally; also exposed for callers that thread
+# over their own TJLF calls (set BLAS=1 once *outside* the threaded region):
+TJLF.with_blas_threads(1) do
+    Threads.@threads for i in eachindex(cases)
+        TJLF.run(cases[i])   # nested scopes short-circuit, no BLAS races
+    end
+end
 ```
 
-- Prevents BLAS from competing with Julia's threading
-- Essential for performance scaling on Linux systems
-- Without this setting, multithreaded performance will degrade significantly
-- TJLF automatically sets `BLAS.set_num_threads(1)` during module initialization
+Notes:
+- A previous version called `BLAS.set_num_threads(1)` at module top level. That
+  has **no effect at runtime** — top-level statements run only during
+  precompilation, and the BLAS thread count is runtime state that is not
+  serialized into the precompile cache. The scoped `with_blas_threads` approach
+  replaces it and works on every load.
+- Setting `export OMP_NUM_THREADS=1` in the shell is still a reasonable
+  belt-and-suspenders (it makes BLAS start single-threaded for *any* BLAS use,
+  including code outside TJLF's scoped drivers), but is no longer required for
+  TJLF's own multithreaded scaling.
 
 ## Threading Architecture
 - Automatic parallelization over multiple `InputTJLF` instances

--- a/ext/TJLFCUDAExt.jl
+++ b/ext/TJLFCUDAExt.jl
@@ -3,11 +3,39 @@ module TJLFCUDAExt
 using CUDA
 using TJLF
 
-# Serializes concurrent GPU solves from Threads.@threads / Distributed workers.
-# CUSOLVER handles are task-local but cusolverDnCreate races when many threads
-# all call it simultaneously on first use. The GPU is already massively parallel
-# internally, so serializing Julia-level dispatch has no performance cost.
-const _GPU_SOLVE_LOCK = ReentrantLock()
+# Per-device dispatch locks. cusolverDnCreate races when many threads call it
+# simultaneously on first use, so Julia-level dispatch is serialized — but only
+# *per device*. Using one lock per GPU (rather than a single global lock) lets
+# solves on different GPUs proceed concurrently, which is what enables
+# multi-GPU-per-radius scaling: e.g. with --gpus-per-task=2 the round-robin below
+# splits a radius's ~1024 eigensolves across both A100s, ~halving per-radius time.
+# Within a single device, dispatch stays serialized (the GPU is internally
+# parallel, so this has negligible cost). With one visible GPU this reduces to a
+# single lock — identical to the previous behavior.
+const _LOCKS_GUARD = ReentrantLock()
+const _GPU_DEVICE_LOCKS = Dict{Int,ReentrantLock}()
+function _device_lock(id::Integer)
+    lock(_LOCKS_GUARD) do
+        get!(() -> ReentrantLock(), _GPU_DEVICE_LOCKS, Int(id))
+    end
+end
+
+# Round-robin counter + cached device list to spread successive solves across all
+# visible GPUs. Lazily initialised (double-checked) so it works whether or not
+# CUDA is functional at load time.
+const _GPU_RR = Threads.Atomic{Int}(0)
+const _DEVICES = Ref{Vector{CuDevice}}(CuDevice[])
+function _devices()
+    devs = _DEVICES[]
+    isempty(devs) || return devs
+    lock(_LOCKS_GUARD) do
+        devs = _DEVICES[]
+        isempty(devs) || return devs
+        devs = collect(CUDA.devices())
+        _DEVICES[] = devs
+        return devs
+    end
+end
 
 function __init__()
     TJLF._CUDA_FUNCTIONAL[]   = () -> CUDA.functional()
@@ -16,7 +44,12 @@ function __init__()
     # (CUSOLVER getrf/getrs for the solve, then Xgeev for the diagonalisation).
     # B is only needed for the LU factorisation; its overwritten form is unused.
     TJLF._CUDA_SOLVE[] = (A::Matrix{ComplexF64}, B::Matrix{ComplexF64}) -> begin
-        lock(_GPU_SOLVE_LOCK) do
+        devs = _devices()
+        n = length(devs)
+        # round-robin device selection across all visible GPUs
+        dev = devs[mod1(Threads.atomic_add!(_GPU_RR, 1) + 1, n)]
+        CUDA.device!(dev)
+        lock(_device_lock(CUDA.deviceid(dev))) do
             A_gpu = CUDA.CuArray(A)
             B_gpu = CUDA.CuArray(B)
             ipiv  = CUDA.CuArray{Int32}(undef, size(B_gpu, 1))

--- a/ext/TJLFCUDAExt.jl
+++ b/ext/TJLFCUDAExt.jl
@@ -59,6 +59,24 @@ function __init__()
             return Array(W)
         end
     end
+
+    # Eigenvector inverse-iteration step on GPU: solve Z x = b (LU via getrf/getrs).
+    # Mirrors _CUDA_SOLVE's device selection + per-device locking so it composes with the
+    # eigenvalue solve (same device, serialized intra-process, overlapped across MPS clients).
+    TJLF._CUDA_LU_SOLVE[] = (Z::Matrix{ComplexF64}, b::Vector{ComplexF64}) -> begin
+        devs = _devices()
+        n = length(devs)
+        dev = devs[mod1(Threads.atomic_add!(_GPU_RR, 1) + 1, n)]
+        CUDA.device!(dev)
+        lock(_device_lock(CUDA.deviceid(dev))) do
+            Z_gpu = CUDA.CuArray(Z)
+            b_gpu = CUDA.CuArray(reshape(b, :, 1))
+            ipiv  = CUDA.CuArray{Int32}(undef, size(Z_gpu, 1))
+            Z_factored, ipiv, _ = CUDA.CUSOLVER.getrf!(Z_gpu, ipiv)
+            x_gpu = CUDA.CUSOLVER.getrs!('N', Z_factored, ipiv, b_gpu)
+            return vec(Array(x_gpu))
+        end
+    end
 end
 
 end

--- a/src/TJLF.jl
+++ b/src/TJLF.jl
@@ -14,6 +14,7 @@ import KrylovKit
 const _CUDA_FUNCTIONAL = Ref{Any}(() -> false)
 const _CUDA_DEVICE_COUNT = Ref{Any}(() -> 0)
 const _CUDA_SOLVE = Ref{Any}(nothing)
+const _CUDA_LU_SOLVE = Ref{Any}(nothing)
 
 # wrappers so call sites stay the same
 _cuda_functional() = _CUDA_FUNCTIONAL[]()
@@ -23,6 +24,13 @@ _cuda_device_count() = _CUDA_DEVICE_COUNT[]()
 function _gpu_solve!(A::Matrix{ComplexF64}, B::Matrix{ComplexF64})
     _CUDA_SOLVE[] === nothing && error("CUDA extension not loaded")
     return _CUDA_SOLVE[](A, B)
+end
+
+# Solve Z x = b on the GPU (CUSOLVER getrf/getrs) and return x::Vector{ComplexF64}.
+# Used for the eigenvector inverse-iteration step (Z = amat - σ·bmat); Z is overwritten.
+function _gpu_lu_solve!(Z::Matrix{ComplexF64}, b::Vector{ComplexF64})
+    _CUDA_LU_SOLVE[] === nothing && error("CUDA extension not loaded")
+    return _CUDA_LU_SOLVE[](Z, b)
 end
 
 # @show BLAS.get_config()

--- a/src/TJLF.jl
+++ b/src/TJLF.jl
@@ -26,7 +26,31 @@ function _gpu_solve!(A::Matrix{ComplexF64}, B::Matrix{ComplexF64})
 end
 
 # @show BLAS.get_config()
-BLAS.set_num_threads(1)
+"""
+    with_blas_threads(f, n::Integer)
+
+Run `f()` with the BLAS thread count temporarily set to `n`, restoring the
+previous value afterwards (even on error). No-op if BLAS is already at `n`.
+
+TJLF parallelises over ky with Julia threads, each doing small dense LAPACK
+solves; with multithreaded BLAS the kernels oversubscribe cores (e.g. 8 Julia
+threads × 128 BLAS threads) and per-solve time balloons ~100x. This is applied
+*scoped* around the threaded compute drivers rather than as a global default, so
+loading TJLF does not change BLAS threading for the rest of a host application
+(e.g. FUSE). The `n0 == n` short-circuit makes nested scopes safe: an inner
+driver running inside an already-set region never touches the global BLAS state,
+avoiding concurrent `set_num_threads` calls from worker threads.
+"""
+@inline function with_blas_threads(f, n::Integer)
+    n0 = BLAS.get_num_threads()
+    n0 == n && return f()
+    BLAS.set_num_threads(n)
+    try
+        return f()
+    finally
+        BLAS.set_num_threads(n0)
+    end
+end
 
 include("tjlf_modules.jl")
 include("tjlf_read_input.jl")

--- a/src/run_tjlf.jl
+++ b/src/run_tjlf.jl
@@ -1,4 +1,10 @@
 function run(inputTJLF::InputTJLF; use_gpu::Bool=false)
+    return with_blas_threads(1) do
+        _run_impl(inputTJLF; use_gpu=use_gpu)
+    end
+end
+
+function _run_impl(inputTJLF::InputTJLF; use_gpu::Bool=false)
     use_tm = inputTJLF.USE_TRANSPORT_MODEL
     if use_tm
         checkInput(inputTJLF)
@@ -103,8 +109,11 @@ description:
 function run_tjlf(input_tjlfs::Vector{InputTJLF{T}}; use_gpu::Bool=false) where {T<:Real}
     checkInput(input_tjlfs)
     outputs = Vector{Array{T,3}}(undef, length(input_tjlfs))
-    Threads.@threads for idx in eachindex(input_tjlfs)
-        outputs[idx] = TJLF.run_tjlf(input_tjlfs[idx]; use_gpu=use_gpu)
+    # set BLAS=1 before spawning threads; the per-element run() short-circuits
+    with_blas_threads(1) do
+        Threads.@threads for idx in eachindex(input_tjlfs)
+            outputs[idx] = TJLF.run_tjlf(input_tjlfs[idx]; use_gpu=use_gpu)
+        end
     end
     return outputs
 end

--- a/src/run_tjlf.jl
+++ b/src/run_tjlf.jl
@@ -1,5 +1,5 @@
 function run(inputTJLF::InputTJLF; use_gpu::Bool=false)
-    use_tm = ismissing(inputTJLF.USE_TRANSPORT_MODEL) ? true : inputTJLF.USE_TRANSPORT_MODEL
+    use_tm = inputTJLF.USE_TRANSPORT_MODEL
     if use_tm
         checkInput(inputTJLF)
         outputHermite = gauss_hermite(inputTJLF)

--- a/src/tjlf_LINEAR_SOLUTION.jl
+++ b/src/tjlf_LINEAR_SOLUTION.jl
@@ -98,16 +98,20 @@ function tjlf_LS(inputs::InputTJLF{T}, satParams::SaturationParameters{T}, outpu
 
     new_matrix = true ######################## hardcode for now ########################
     if (new_matrix)
+        _tg0 = PROBE[] ? time_ns() : UInt64(0)
         ave, aveH, aveWH, aveKH,
         aveG, aveWG, aveKG,
         aveGrad, aveGradB = get_matrix(inputs, outputGeo, outputHermite, ky, nbasis, ky_index; aves)
+        PROBE[] && Threads.atomic_add!(_PROBE_T_GETMAT, Int(time_ns() - _tg0))
     end
 
     K = Complex{T}
     amat = Matrix{K}(undef, iur, iur)
     bmat = Matrix{K}(undef, iur, iur)
     #  solver for linear eigenmodes of tglf equations
+    _te0 = PROBE[] ? time_ns() : UInt64(0)
     eigenvalues, v = tjlf_eigensolver(inputs,outputGeo,satParams,ave,aveH,aveWH,aveKH,aveG,aveWG,aveKG,aveGrad,aveGradB, nbasis,ky, amat,bmat,ky_index,find_eigenvector; use_gpu=use_gpu)
+    PROBE[] && Threads.atomic_add!(_PROBE_T_EIGSOLVE, Int(time_ns() - _te0))
 
     rr = real.(eigenvalues)
     ri = imag.(eigenvalues)
@@ -253,23 +257,38 @@ function tjlf_LS(inputs::InputTJLF{T}, satParams::SaturationParameters{T}, outpu
         end
         for imax = 1:nmodes_out
             if (jmax[imax] > 0)
+                PROBE[] && Threads.atomic_add!(_PROBE_EIGVEC, 1)
+                _tv0 = PROBE[] ? time_ns() : UInt64(0)
                 if inputs.SMALL != 0.0
+                    PROBE[] && Threads.atomic_add!(_PROBE_N_INVITER, 1)
                     # calculate eigenvector
                     eigenvector .= inputs.SMALL
                     # alpha and beta from eigensolver.jl
                     @. zmat = amat - (inputs.SMALL + rr[jmax[imax]] + im * ri[jmax[imax]]) * bmat
 
-                    eigenvector .= zmat \ eigenvector
+                    _tb0 = PROBE[] ? time_ns() : UInt64(0)
+                    # in-place inverse iteration: lu!(zmat) factors in place (no
+                    # matrix copy), ldiv! solves in place. zmat is rebuilt fresh
+                    # each iteration above, so destroying it here is safe. This
+                    # avoids the ~2.24 MiB/solve allocation of `zmat \ rhs`, which
+                    # under multithreading triggered heavy GC contention.
+                    ldiv!(lu!(zmat), eigenvector)
+                    PROBE[] && Threads.atomic_add!(_PROBE_T_BSLASH, Int(time_ns() - _tb0))
                 else
                     if inputs.FIND_EIGEN || isnan(v[1,1])
+                        PROBE[] && Threads.atomic_add!(_PROBE_N_KRYLOV, 1)
                         nev1 = size(amat)[1]                           
+                        _tb0 = PROBE[] ? time_ns() : UInt64(0)
                         L = construct_linear_map(sparse(amat), sparse(bmat), eigenvalues[jmax[imax]])
                         _, vec, _ = KrylovKit.eigsolve(L, nev1, 1, :LM)
                         eigenvector = vec[1]
+                        PROBE[] && Threads.atomic_add!(_PROBE_T_BSLASH, Int(time_ns() - _tb0))
                     else
+                        PROBE[] && Threads.atomic_add!(_PROBE_N_REUSE, 1)
                         eigenvector = v[:, jmax[imax]]
                     end
                 end
+                PROBE[] && Threads.atomic_add!(_PROBE_T_EIGVEC, Int(time_ns() - _tv0))
 
                 Ns_Ts_phase,
                 Ne_Te_phase,

--- a/src/tjlf_LINEAR_SOLUTION.jl
+++ b/src/tjlf_LINEAR_SOLUTION.jl
@@ -267,12 +267,20 @@ function tjlf_LS(inputs::InputTJLF{T}, satParams::SaturationParameters{T}, outpu
                     @. zmat = amat - (inputs.SMALL + rr[jmax[imax]] + im * ri[jmax[imax]]) * bmat
 
                     _tb0 = PROBE[] ? time_ns() : UInt64(0)
-                    # in-place inverse iteration: lu!(zmat) factors in place (no
-                    # matrix copy), ldiv! solves in place. zmat is rebuilt fresh
-                    # each iteration above, so destroying it here is safe. This
-                    # avoids the ~2.24 MiB/solve allocation of `zmat \ rhs`, which
-                    # under multithreading triggered heavy GC contention.
-                    ldiv!(lu!(zmat), eigenvector)
+                    if use_gpu && K === ComplexF64 && get(ENV, "TJLF_GPU_EIGVEC", "1") == "1"
+                        # Inverse-iteration LU solve on the GPU (CUSOLVER getrf/getrs),
+                        # mirroring the eigenvalue solve. Moves this O(n^3) factorisation
+                        # off the CPU; overwrites zmat. Set TJLF_GPU_EIGVEC=0 to force the
+                        # CPU path (for A/B timing). Falls back to CPU below otherwise.
+                        eigenvector = TJLF._gpu_lu_solve!(zmat, eigenvector)
+                    else
+                        # in-place inverse iteration: lu!(zmat) factors in place (no
+                        # matrix copy), ldiv! solves in place. zmat is rebuilt fresh
+                        # each iteration above, so destroying it here is safe. This
+                        # avoids the ~2.24 MiB/solve allocation of `zmat \ rhs`, which
+                        # under multithreading triggered heavy GC contention.
+                        ldiv!(lu!(zmat), eigenvector)
+                    end
                     PROBE[] && Threads.atomic_add!(_PROBE_T_BSLASH, Int(time_ns() - _tb0))
                 else
                     if inputs.FIND_EIGEN || isnan(v[1,1])

--- a/src/tjlf_LINEAR_SOLUTION.jl
+++ b/src/tjlf_LINEAR_SOLUTION.jl
@@ -98,20 +98,16 @@ function tjlf_LS(inputs::InputTJLF{T}, satParams::SaturationParameters{T}, outpu
 
     new_matrix = true ######################## hardcode for now ########################
     if (new_matrix)
-        _tg0 = PROBE[] ? time_ns() : UInt64(0)
         ave, aveH, aveWH, aveKH,
         aveG, aveWG, aveKG,
         aveGrad, aveGradB = get_matrix(inputs, outputGeo, outputHermite, ky, nbasis, ky_index; aves)
-        PROBE[] && Threads.atomic_add!(_PROBE_T_GETMAT, Int(time_ns() - _tg0))
     end
 
     K = Complex{T}
     amat = Matrix{K}(undef, iur, iur)
     bmat = Matrix{K}(undef, iur, iur)
     #  solver for linear eigenmodes of tglf equations
-    _te0 = PROBE[] ? time_ns() : UInt64(0)
     eigenvalues, v = tjlf_eigensolver(inputs,outputGeo,satParams,ave,aveH,aveWH,aveKH,aveG,aveWG,aveKG,aveGrad,aveGradB, nbasis,ky, amat,bmat,ky_index,find_eigenvector; use_gpu=use_gpu)
-    PROBE[] && Threads.atomic_add!(_PROBE_T_EIGSOLVE, Int(time_ns() - _te0))
 
     rr = real.(eigenvalues)
     ri = imag.(eigenvalues)
@@ -257,21 +253,16 @@ function tjlf_LS(inputs::InputTJLF{T}, satParams::SaturationParameters{T}, outpu
         end
         for imax = 1:nmodes_out
             if (jmax[imax] > 0)
-                PROBE[] && Threads.atomic_add!(_PROBE_EIGVEC, 1)
-                _tv0 = PROBE[] ? time_ns() : UInt64(0)
                 if inputs.SMALL != 0.0
-                    PROBE[] && Threads.atomic_add!(_PROBE_N_INVITER, 1)
                     # calculate eigenvector
                     eigenvector .= inputs.SMALL
                     # alpha and beta from eigensolver.jl
                     @. zmat = amat - (inputs.SMALL + rr[jmax[imax]] + im * ri[jmax[imax]]) * bmat
 
-                    _tb0 = PROBE[] ? time_ns() : UInt64(0)
-                    if use_gpu && K === ComplexF64 && get(ENV, "TJLF_GPU_EIGVEC", "1") == "1"
+                    if use_gpu && K === ComplexF64
                         # Inverse-iteration LU solve on the GPU (CUSOLVER getrf/getrs),
                         # mirroring the eigenvalue solve. Moves this O(n^3) factorisation
-                        # off the CPU; overwrites zmat. Set TJLF_GPU_EIGVEC=0 to force the
-                        # CPU path (for A/B timing). Falls back to CPU below otherwise.
+                        # off the CPU; overwrites zmat.
                         eigenvector = TJLF._gpu_lu_solve!(zmat, eigenvector)
                     else
                         # in-place inverse iteration: lu!(zmat) factors in place (no
@@ -281,22 +272,16 @@ function tjlf_LS(inputs::InputTJLF{T}, satParams::SaturationParameters{T}, outpu
                         # under multithreading triggered heavy GC contention.
                         ldiv!(lu!(zmat), eigenvector)
                     end
-                    PROBE[] && Threads.atomic_add!(_PROBE_T_BSLASH, Int(time_ns() - _tb0))
                 else
                     if inputs.FIND_EIGEN || isnan(v[1,1])
-                        PROBE[] && Threads.atomic_add!(_PROBE_N_KRYLOV, 1)
-                        nev1 = size(amat)[1]                           
-                        _tb0 = PROBE[] ? time_ns() : UInt64(0)
+                        nev1 = size(amat)[1]
                         L = construct_linear_map(sparse(amat), sparse(bmat), eigenvalues[jmax[imax]])
                         _, vec, _ = KrylovKit.eigsolve(L, nev1, 1, :LM)
                         eigenvector = vec[1]
-                        PROBE[] && Threads.atomic_add!(_PROBE_T_BSLASH, Int(time_ns() - _tb0))
                     else
-                        PROBE[] && Threads.atomic_add!(_PROBE_N_REUSE, 1)
                         eigenvector = v[:, jmax[imax]]
                     end
                 end
-                PROBE[] && Threads.atomic_add!(_PROBE_T_EIGVEC, Int(time_ns() - _tv0))
 
                 Ns_Ts_phase,
                 Ne_Te_phase,

--- a/src/tjlf_eigensolver.jl
+++ b/src/tjlf_eigensolver.jl
@@ -11,6 +11,7 @@ const _PROBE_CAP     = Ref{Any}(nothing)        # one captured (amat,bmat) for k
 # in-situ CPU-time accumulators (ns, summed across threads)
 const _PROBE_T_GETMAT   = Threads.Atomic{Int}(0)  # get_matrix (ave* assembly)
 const _PROBE_T_EIGSOLVE = Threads.Atomic{Int}(0)  # tjlf_eigensolver call (amat/bmat fill + eigenvalue solve)
+const _PROBE_T_SOLVE    = Threads.Atomic{Int}(0)  # JUST the eigenvalue solve (_standard_eigenvalues_via_solve)
 const _PROBE_T_EIGVEC   = Threads.Atomic{Int}(0)  # eigenvector solve (whole block)
 const _PROBE_T_BSLASH   = Threads.Atomic{Int}(0)  # just the \ (or KrylovKit) inside the eigenvector block
 # which eigenvector branch was taken
@@ -26,6 +27,7 @@ function reset_probe!()
     _PROBE_CAP[]    = nothing
     _PROBE_T_GETMAT[]   = 0
     _PROBE_T_EIGSOLVE[] = 0
+    _PROBE_T_SOLVE[]    = 0
     _PROBE_T_EIGVEC[]   = 0
     _PROBE_T_BSLASH[]   = 0
     _PROBE_N_INVITER[]  = 0
@@ -40,6 +42,7 @@ probe_stats() = (eigval_solves = _PROBE_EIGVAL[],
                  eigvec_solves = _PROBE_EIGVEC[],
                  t_getmat_s    = _PROBE_T_GETMAT[]   / 1e9,
                  t_eigsolve_s  = _PROBE_T_EIGSOLVE[] / 1e9,
+                 t_solve_s     = _PROBE_T_SOLVE[]    / 1e9,
                  t_eigvec_s    = _PROBE_T_EIGVEC[]   / 1e9,
                  t_bslash_s    = _PROBE_T_BSLASH[]   / 1e9,
                  n_inviter     = _PROBE_N_INVITER[],
@@ -2793,9 +2796,13 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
             if inputs.IFLUX || find_eigenvector
                 amat_copy = copy(amat)
                 bmat_copy = copy(bmat)
+                _ts0 = PROBE[] ? time_ns() : UInt64(0)
                 alpha = _standard_eigenvalues_via_solve(amat_copy, bmat_copy; use_gpu=use_gpu)
+                PROBE[] && Threads.atomic_add!(_PROBE_T_SOLVE, Int(time_ns() - _ts0))
             else
+                _ts0 = PROBE[] ? time_ns() : UInt64(0)
                 alpha = _standard_eigenvalues_via_solve(amat, bmat; use_gpu=use_gpu)
+                PROBE[] && Threads.atomic_add!(_PROBE_T_SOLVE, Int(time_ns() - _ts0))
             end
             return alpha, fill(NaN*im,(1,1))
         end
@@ -2803,9 +2810,13 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
         if inputs.IFLUX || find_eigenvector
             amat_copy = copy(amat)
             bmat_copy = copy(bmat)
+            _ts0 = PROBE[] ? time_ns() : UInt64(0)
             alpha = _standard_eigenvalues_via_solve(amat_copy, bmat_copy; use_gpu=use_gpu)
+            PROBE[] && Threads.atomic_add!(_PROBE_T_SOLVE, Int(time_ns() - _ts0))
         else
+            _ts0 = PROBE[] ? time_ns() : UInt64(0)
             alpha = _standard_eigenvalues_via_solve(amat, bmat; use_gpu=use_gpu)
+            PROBE[] && Threads.atomic_add!(_PROBE_T_SOLVE, Int(time_ns() - _ts0))
         end
 
     else
@@ -2813,7 +2824,9 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
         # non-transport-model path would otherwise run (its result is unused).
         amat_copy = copy(amat)
         bmat_copy = copy(bmat)
+        _ts0 = PROBE[] ? time_ns() : UInt64(0)
         alpha = _standard_eigenvalues_via_solve(amat_copy, bmat_copy; use_gpu=use_gpu)
+        PROBE[] && Threads.atomic_add!(_PROBE_T_SOLVE, Int(time_ns() - _ts0))
     end
 
     return alpha, fill(NaN*im,(1,1))

--- a/src/tjlf_eigensolver.jl
+++ b/src/tjlf_eigensolver.jl
@@ -1124,20 +1124,20 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
                     ia = nbasis+ib + ia0
 
                     phi_A = N_j*im*w_s*vpar_shear[is]*hp1/vsIS
-                    phi_B = 0.0
+                    phi_B = zero(K)
                     if(vpar_model_in==0)
                         phi_A = phi_A  +N_j*im*w_cd*wdhp1p0*vpar[is]/vsIS
                             + d_1*(nuei_u_u_1+nuei_u_q3_1*5.0/3.0)*hp1*E_i*N_j*vpar[is]/vsIS
                         phi_B = -E_i*N_j*hp1*vpar[is]/vsIS
                     end
-                    sig_A = 0.0
-                    sig_B = 0.0
-                    psi_A = 0.0
-                    psi_B = 0.0
-                    phi_AU = 0.0
-                    phi_BU = 0.0
-                    psi_AN = 0.0
-                    psi_BN = 0.0
+                    sig_A = zero(K)
+                    sig_B = zero(K)
+                    psi_A = zero(K)
+                    psi_B = zero(K)
+                    phi_AU = zero(K)
+                    phi_BU = zero(K)
+                    psi_AN = zero(K)
+                    psi_BN = zero(K)
                     if(use_bper_in)
                         psi_A = -betae_psi*J_j*vsIS*im*w_s*(rlnsIS*hp1b0+1.5*rltsIS*(hr13b0-hp1b0))
                         psi_B = betae_psi*M_i*J_j*hp1b0
@@ -1233,14 +1233,14 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
                         phi_A = phi_A +N_j*E_i*kpar_hp1p0*vpar[is]
                     end
                     phi_B = -hp1*E_i*N_j
-                    sig_A = 0.0
-                    sig_B = 0.0
-                    psi_A = 0.0
-                    psi_B = 0.0
-                    phi_AU = 0.0
-                    phi_BU = 0.0
-                    psi_AN = 0.0
-                    psi_BN = 0.0
+                    sig_A = zero(K)
+                    sig_B = zero(K)
+                    psi_A = zero(K)
+                    psi_B = zero(K)
+                    phi_AU = zero(K)
+                    phi_BU = zero(K)
+                    psi_AN = zero(K)
+                    psi_BN = zero(K)
                     if(use_bpar_in)
                         sig_A = -betae_sig*(asJS*tausJS*zsIS/massIS)*(im*w_s*(rlnsIS*h10p1 + rltsIS*1.5*(h10r13-h10p1)))
                         sig_B = betae_sig*h10p1*asJS*tausJS*zsIS*zsIS/(tausIS*massIS)
@@ -1347,14 +1347,14 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
                         phi_A = phi_A + N_j*E_i*kpar_hp3p0*vpar[is]
                     end
                     phi_B = -hp3*E_i*N_j
-                    sig_A = 0.0
-                    sig_B = 0.0
-                    psi_A = 0.0
-                    psi_B = 0.0
-                    phi_AU = 0.0
-                    phi_BU = 0.0
-                    psi_AN = 0.0
-                    psi_BN = 0.0
+                    sig_A = zero(K)
+                    sig_B = zero(K)
+                    psi_A = zero(K)
+                    psi_B = zero(K)
+                    phi_AU = zero(K)
+                    phi_BU = zero(K)
+                    psi_AN = zero(K)
+                    psi_BN = zero(K)
                     if(use_bpar_in)
                         sig_A = -betae_sig*(asJS*tausJS*zsIS/massIS) * (im*w_s*(rlnsIS*h10p3 + rltsIS*1.5*(h10r33-h10p3)))
                         sig_B = betae_sig*h10p3*asJS*tausJS*zsIS*zsIS /(tausIS*massIS)
@@ -1455,21 +1455,21 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
                     ia = 4*nbasis+ib + ia0
 
                     phi_A = N_j*im*w_s*hr11*vpar_shear[is]/vsIS
-                    phi_B = 0.0
+                    phi_B = zero(K)
                     if(vpar_model_in==0)
                         phi_A = (phi_A +N_j*im*w_cd*wdhr11p0*vpar[is]/vsIS
                                 + d_1*(nuei_q1_u_1 + (5/3)*nuei_q1_q3_1+3*nuei_q1_q1_1)
                                 *hr11*E_i*N_j*vpar[is]/vsIS)
                         phi_B = -E_i*N_j*hr11*vpar[is]/vsIS
                     end
-                    sig_A = 0.0
-                    sig_B = 0.0
-                    psi_A = 0.0
-                    psi_B = 0.0
-                    phi_AU = 0.0
-                    phi_BU = 0.0
-                    psi_AN = 0.0
-                    psi_BN = 0.0
+                    sig_A = zero(K)
+                    sig_B = zero(K)
+                    psi_A = zero(K)
+                    psi_B = zero(K)
+                    phi_AU = zero(K)
+                    phi_BU = zero(K)
+                    psi_AN = zero(K)
+                    psi_BN = zero(K)
                     if(use_bper_in)
                         psi_A = -betae_psi*J_j*vsIS*im*w_s*(rlnsIS*hr11b0+1.5*rltsIS*(hw113b0-hr11b0))
                         psi_B =betae_psi*M_i*J_j*hr11b0
@@ -1573,21 +1573,21 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
                     ia = 5*nbasis+ib + ia0
 
                     phi_A = N_j*im*w_s*vpar_shear[is]*hr13/vsIS
-                    phi_B = 0.0
+                    phi_B = zero(K)
                     if(vpar_model_in==0)
                         phi_A = (phi_A +N_j*im*w_cd*wdhr13p0*vpar[is]/vsIS
                                 + d_1*(nuei_q3_u_1 + (5.0/3.0)*nuei_q3_q3_1)
                                 *hr13*E_i*N_j*vpar[is]/vsIS)
                         phi_B = -E_i*N_j*hr13*vpar[is]/vsIS
                     end
-                    sig_A = 0.0
-                    sig_B = 0.0
-                    psi_A = 0.0
-                    psi_B = 0.0
-                    phi_AU = 0.0
-                    phi_BU = 0.0
-                    psi_AN = 0.0
-                    psi_BN = 0.0
+                    sig_A = zero(K)
+                    sig_B = zero(K)
+                    psi_A = zero(K)
+                    psi_B = zero(K)
+                    phi_AU = zero(K)
+                    phi_BU = zero(K)
+                    psi_AN = zero(K)
+                    psi_BN = zero(K)
                     if(use_bper_in)
                         psi_A = -betae_psi*J_j*vsIS*im*w_s*(rlnsIS*hr13b0+1.5*rltsIS*(hw133b0-hr13b0))
                         psi_B = hr13b0*betae_psi*M_i*J_j
@@ -1698,14 +1698,14 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
                         end
                         phi_B = -E_i*N_j*gn
                         phi_A = phi_A +xnu_phi_b*xnuei*xnu_n_b*phi_B
-                        sig_A = 0.0
-                        sig_B = 0.0
-                        psi_A = 0.0
-                        psi_B = 0.0
-                        phi_AU = 0.0
-                        phi_BU = 0.0
-                        psi_AN = 0.0
-                        psi_BN = 0.0
+                        sig_A = zero(K)
+                        sig_B = zero(K)
+                        psi_A = zero(K)
+                        psi_B = zero(K)
+                        phi_AU = zero(K)
+                        phi_BU = zero(K)
+                        psi_AN = zero(K)
+                        psi_BN = zero(K)
                         if(use_bpar_in)
                             sig_A = (-betae_sig*(asJS*tausJS*zsIS/massIS)*
                                     (im*w_s*(rlnsIS*g10n + rltsIS*1.5*(g10p3-g10n))))
@@ -1806,14 +1806,14 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
                             phi_A = phi_A  + N_j*im*w_cd*wdgp1p0*vpar[is]/vsIS
                             phi_B = -E_i*N_j*gp1*vpar[is]/vsIS
                         end
-                        sig_A = 0.0
-                        sig_B = 0.0
-                        psi_A = 0.0
-                        psi_B = 0.0
-                        phi_AU = 0.0
-                        phi_BU = 0.0
-                        psi_AN = 0.0
-                        psi_BN = 0.0
+                        sig_A = zero(K)
+                        sig_B = zero(K)
+                        psi_A = zero(K)
+                        psi_B = zero(K)
+                        phi_AU = zero(K)
+                        phi_BU = zero(K)
+                        psi_AN = zero(K)
+                        psi_BN = zero(K)
                         if(use_bper_in)
                             psi_A = -betae_psi*J_j*vsIS*im*w_s*(rlnsIS*gp1b0+1.5*rltsIS*(gr13b0-gp1b0))
                             psi_B =betae_psi*M_i*J_j*gp1b0
@@ -1914,14 +1914,14 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
                         end
                         phi_B = -E_i*N_j*gp1
                         phi_A = phi_A +xnu_phi_b*xnuei*xnu_p1_b*phi_B
-                        sig_A = 0.0
-                        sig_B = 0.0
-                        psi_A = 0.0
-                        psi_B = 0.0
-                        phi_AU = 0.0
-                        phi_BU = 0.0
-                        psi_AN = 0.0
-                        psi_BN = 0.0
+                        sig_A = zero(K)
+                        sig_B = zero(K)
+                        psi_A = zero(K)
+                        psi_B = zero(K)
+                        phi_AU = zero(K)
+                        phi_BU = zero(K)
+                        psi_AN = zero(K)
+                        psi_BN = zero(K)
                         if(use_bpar_in)
                             sig_A =( -betae_sig*(asJS*tausJS*zsIS/massIS)*
                                     (im*w_s*(rlnsIS*g10p1 + rltsIS*1.5*(g10r13-g10p1))))
@@ -2032,14 +2032,14 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
                         end
                         phi_B = -gp3*E_i*N_j
                         phi_A = phi_A +xnu_phi_b*xnuei*xnu_p3_b*phi_B
-                        sig_A = 0.0
-                        sig_B = 0.0
-                        psi_A = 0.0
-                        psi_B = 0.0
-                        phi_AU = 0.0
-                        phi_BU = 0.0
-                        psi_AN = 0.0
-                        psi_BN = 0.0
+                        sig_A = zero(K)
+                        sig_B = zero(K)
+                        psi_A = zero(K)
+                        psi_B = zero(K)
+                        phi_AU = zero(K)
+                        phi_BU = zero(K)
+                        psi_AN = zero(K)
+                        psi_BN = zero(K)
                         if(use_bpar_in)
                             sig_A = (-betae_sig*(asJS*tausJS*zsIS/massIS)*
                                     (im*w_s*(rlnsIS*g10p3 + rltsIS*1.5*(g10r33-g10p3))))
@@ -2147,14 +2147,14 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
                             phi_A = phi_A + N_j*im*w_cd*wdgr11p0*vpar[is]/vsIS
                             phi_B = -E_i*N_j*gr11*vpar[is]/vsIS
                         end
-                        sig_A = 0.0
-                        sig_B = 0.0
-                        psi_A = 0.0
-                        psi_B = 0.0
-                        phi_AU = 0.0
-                        phi_BU = 0.0
-                        psi_AN = 0.0
-                        psi_BN = 0.0
+                        sig_A = zero(K)
+                        sig_B = zero(K)
+                        psi_A = zero(K)
+                        psi_B = zero(K)
+                        phi_AU = zero(K)
+                        phi_BU = zero(K)
+                        psi_AN = zero(K)
+                        psi_BN = zero(K)
                         if(use_bper_in)
                             psi_A = -betae_psi*J_j*vsIS*im*w_s*(rlnsIS*gr11b0+1.5*rltsIS*(gw113b0-gr11b0))
                             psi_B = gr11b0*betae_psi*M_i*J_j
@@ -2256,14 +2256,14 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
                             phi_A = phi_A + N_j*im*w_cd*wdgr13p0*vpar[is]/vsIS
                             phi_B = -E_i*N_j*gr13*vpar[is]/vsIS
                         end
-                        sig_A = 0.0
-                        sig_B = 0.0
-                        psi_A = 0.0
-                        psi_B = 0.0
-                        phi_AU = 0.0
-                        phi_BU = 0.0
-                        psi_AN = 0.0
-                        psi_BN = 0.0
+                        sig_A = zero(K)
+                        sig_B = zero(K)
+                        psi_A = zero(K)
+                        psi_B = zero(K)
+                        phi_AU = zero(K)
+                        phi_BU = zero(K)
+                        psi_AN = zero(K)
+                        psi_BN = zero(K)
                         if(use_bper_in)
                             psi_A = -betae_psi*J_j*vsIS*im*w_s*(rlnsIS*gr13b0+1.5*rltsIS*(gw133b0-gr13b0))
                             psi_B = gr13b0*betae_psi*M_i*J_j
@@ -2363,14 +2363,14 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
                         phi_A = N_j*im*w_s*(rlnsIS*gn + rltsIS*1.5*(gp3-gn))
                         phi_B = -gn*E_i*N_j
                         phi_A = phi_A +xnu_phi_b*xnuei*xnu_n_b*phi_B
-                        sig_A = 0.0
-                        sig_B = 0.0
-                        psi_A = 0.0
-                        psi_B = 0.0
-                        phi_AU = 0.0
-                        phi_BU = 0.0
-                        psi_AN = 0.0
-                        psi_BN = 0.0
+                        sig_A = zero(K)
+                        sig_B = zero(K)
+                        psi_A = zero(K)
+                        psi_B = zero(K)
+                        phi_AU = zero(K)
+                        phi_BU = zero(K)
+                        psi_AN = zero(K)
+                        psi_BN = zero(K)
                         if(use_bpar_in)
                             sig_A = (-betae_sig*(asJS*tausJS*zsIS/massIS)*
                                     (im*w_s*(rlnsIS*g10n + rltsIS*1.5*(g10p3-g10n))))
@@ -2467,14 +2467,14 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
                         phi_A = N_j*im*w_s*(rlnsIS*gp1 + rltsIS*1.5*(gr13-gp1))
                         phi_B = -gp1*E_i*N_j
                         phi_A = phi_A +xnu_phi_b*xnuei*xnu_p1_b*phi_B
-                        sig_A = 0.0
-                        sig_B = 0.0
-                        psi_A = 0.0
-                        psi_B = 0.0
-                        phi_AU = 0.0
-                        phi_BU = 0.0
-                        psi_AN = 0.0
-                        psi_BN = 0.0
+                        sig_A = zero(K)
+                        sig_B = zero(K)
+                        psi_A = zero(K)
+                        psi_B = zero(K)
+                        phi_AU = zero(K)
+                        phi_BU = zero(K)
+                        psi_AN = zero(K)
+                        psi_BN = zero(K)
                         if(use_bpar_in)
                             sig_A = (-betae_sig*(asJS*tausJS*zsIS/massIS)*
                                     (im*w_s*(rlnsIS*g10p1 + rltsIS*1.5*(g10r13-g10p1))))
@@ -2580,14 +2580,14 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
                         phi_A = N_j*im*w_s*(rlnsIS*gp3+rltsIS*1.5*(gr33-gp3))
                         phi_B = -gp3*E_i*N_j
                         phi_A = phi_A +xnu_phi_b*xnuei*xnu_p3_b*phi_B
-                        sig_A = 0.0
-                        sig_B = 0.0
-                        psi_A = 0.0
-                        psi_B = 0.0
-                        phi_AU = 0.0
-                        phi_BU = 0.0
-                        psi_AN = 0.0
-                        psi_BN = 0.0
+                        sig_A = zero(K)
+                        sig_B = zero(K)
+                        psi_A = zero(K)
+                        psi_B = zero(K)
+                        phi_AU = zero(K)
+                        phi_BU = zero(K)
+                        psi_AN = zero(K)
+                        psi_BN = zero(K)
                         if(use_bpar_in)
                             sig_A =( -betae_sig*(asJS*tausJS*zsIS/massIS)*
                                     (im*w_s*(rlnsIS*g10p3 + rltsIS*1.5*(g10r33-g10p3))))
@@ -2722,7 +2722,7 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
         end
     end
 
-    use_tm = ismissing(inputs.USE_TRANSPORT_MODEL) ? true : inputs.USE_TRANSPORT_MODEL
+    use_tm = inputs.USE_TRANSPORT_MODEL
     if !use_gpu
         if !use_tm
             if inputs.IFLUX || find_eigenvector

--- a/src/tjlf_eigensolver.jl
+++ b/src/tjlf_eigensolver.jl
@@ -1,3 +1,52 @@
+# ── Opt-in perf probe (zero overhead when PROBE[] == false) ──────────────────
+# Counts eigenvalue solves + matrix sizes (and eigenvector solves, incremented in
+# tjlf_LINEAR_SOLUTION.jl) so we can attribute the per-radius cost. Toggle with
+# TJLF.PROBE[] = true; call TJLF.reset_probe!() first. Thread-safe via atomics.
+const PROBE          = Ref(false)
+const _PROBE_EIGVAL  = Threads.Atomic{Int}(0)   # # of tjlf_eigensolver solves
+const _PROBE_SZSUM   = Threads.Atomic{Int}(0)   # Σ matrix dim (iur) over solves
+const _PROBE_SZMAX   = Threads.Atomic{Int}(0)   # max matrix dim seen
+const _PROBE_EIGVEC  = Threads.Atomic{Int}(0)   # # of eigenvector solves
+const _PROBE_CAP     = Ref{Any}(nothing)        # one captured (amat,bmat) for kernel benchmarking
+# in-situ CPU-time accumulators (ns, summed across threads)
+const _PROBE_T_GETMAT   = Threads.Atomic{Int}(0)  # get_matrix (ave* assembly)
+const _PROBE_T_EIGSOLVE = Threads.Atomic{Int}(0)  # tjlf_eigensolver call (amat/bmat fill + eigenvalue solve)
+const _PROBE_T_EIGVEC   = Threads.Atomic{Int}(0)  # eigenvector solve (whole block)
+const _PROBE_T_BSLASH   = Threads.Atomic{Int}(0)  # just the \ (or KrylovKit) inside the eigenvector block
+# which eigenvector branch was taken
+const _PROBE_N_INVITER  = Threads.Atomic{Int}(0)  # SMALL!=0 inverse-iteration (zmat \ rhs)
+const _PROBE_N_KRYLOV   = Threads.Atomic{Int}(0)  # SMALL==0 && (FIND_EIGEN||isnan) KrylovKit path
+const _PROBE_N_REUSE    = Threads.Atomic{Int}(0)  # SMALL==0 reuse v[:,jmax]
+
+function reset_probe!()
+    _PROBE_EIGVAL[] = 0
+    _PROBE_SZSUM[]  = 0
+    _PROBE_SZMAX[]  = 0
+    _PROBE_EIGVEC[] = 0
+    _PROBE_CAP[]    = nothing
+    _PROBE_T_GETMAT[]   = 0
+    _PROBE_T_EIGSOLVE[] = 0
+    _PROBE_T_EIGVEC[]   = 0
+    _PROBE_T_BSLASH[]   = 0
+    _PROBE_N_INVITER[]  = 0
+    _PROBE_N_KRYLOV[]   = 0
+    _PROBE_N_REUSE[]    = 0
+    return nothing
+end
+
+probe_stats() = (eigval_solves = _PROBE_EIGVAL[],
+                 size_sum      = _PROBE_SZSUM[],
+                 size_max      = _PROBE_SZMAX[],
+                 eigvec_solves = _PROBE_EIGVEC[],
+                 t_getmat_s    = _PROBE_T_GETMAT[]   / 1e9,
+                 t_eigsolve_s  = _PROBE_T_EIGSOLVE[] / 1e9,
+                 t_eigvec_s    = _PROBE_T_EIGVEC[]   / 1e9,
+                 t_bslash_s    = _PROBE_T_BSLASH[]   / 1e9,
+                 n_inviter     = _PROBE_N_INVITER[],
+                 n_krylov      = _PROBE_N_KRYLOV[],
+                 n_reuse       = _PROBE_N_REUSE[],
+                 captured      = _PROBE_CAP[])
+
 """
     tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satParams::SaturationParameters{T},ave::Ave{T},aveH::AveH{T},aveWH::AveWH{T},aveKH::AveKH,aveG::AveG{T},aveWG::AveWG{T},aveKG::AveKG,aveGrad::AveGrad{T},aveGradB::AveGradB{T},nbasis::Int, ky::T,amat::Matrix{K},bmat::Matrix{K},ky_index::Int) where T<:Real where K<:Complex
 
@@ -2719,6 +2768,16 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
             end
         else
             @warn "no growth rate initial guess given for ky = $(inputs.KY_SPECTRUM[ky_index]), using gesv!+geev! to find all eigenvalues"
+        end
+    end
+
+    if PROBE[]
+        n = size(amat, 1)
+        Threads.atomic_add!(_PROBE_EIGVAL, 1)
+        Threads.atomic_add!(_PROBE_SZSUM, n)
+        Threads.atomic_max!(_PROBE_SZMAX, n)
+        if _PROBE_CAP[] === nothing
+            _PROBE_CAP[] = (copy(amat), copy(bmat))
         end
     end
 

--- a/src/tjlf_eigensolver.jl
+++ b/src/tjlf_eigensolver.jl
@@ -2784,12 +2784,18 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
     use_tm = inputs.USE_TRANSPORT_MODEL
     if !use_gpu
         if !use_tm
+            # Eigenvalues via the standard solve B⁻¹A (gesv! + geev!) instead of
+            # the generalized ggev!. For these well-conditioned pencils the two
+            # agree to ~1e-11 relative, but gesv!+geev! is ~4x faster on the small
+            # dense matrices here (e.g. 270×270: 179 ms -> 45 ms). This also makes
+            # the CPU non-transport path match the GPU path, which already solves
+            # this way (see the use_gpu branch below).
             if inputs.IFLUX || find_eigenvector
                 amat_copy = copy(amat)
                 bmat_copy = copy(bmat)
-                alpha = _generalized_eigenvalues(amat_copy, bmat_copy)
+                alpha = _standard_eigenvalues_via_solve(amat_copy, bmat_copy; use_gpu=use_gpu)
             else
-                alpha = _generalized_eigenvalues(amat, bmat)
+                alpha = _standard_eigenvalues_via_solve(amat, bmat; use_gpu=use_gpu)
             end
             return alpha, fill(NaN*im,(1,1))
         end

--- a/src/tjlf_eigensolver.jl
+++ b/src/tjlf_eigensolver.jl
@@ -1,55 +1,3 @@
-# ── Opt-in perf probe (zero overhead when PROBE[] == false) ──────────────────
-# Counts eigenvalue solves + matrix sizes (and eigenvector solves, incremented in
-# tjlf_LINEAR_SOLUTION.jl) so we can attribute the per-radius cost. Toggle with
-# TJLF.PROBE[] = true; call TJLF.reset_probe!() first. Thread-safe via atomics.
-const PROBE          = Ref(false)
-const _PROBE_EIGVAL  = Threads.Atomic{Int}(0)   # # of tjlf_eigensolver solves
-const _PROBE_SZSUM   = Threads.Atomic{Int}(0)   # Σ matrix dim (iur) over solves
-const _PROBE_SZMAX   = Threads.Atomic{Int}(0)   # max matrix dim seen
-const _PROBE_EIGVEC  = Threads.Atomic{Int}(0)   # # of eigenvector solves
-const _PROBE_CAP     = Ref{Any}(nothing)        # one captured (amat,bmat) for kernel benchmarking
-# in-situ CPU-time accumulators (ns, summed across threads)
-const _PROBE_T_GETMAT   = Threads.Atomic{Int}(0)  # get_matrix (ave* assembly)
-const _PROBE_T_EIGSOLVE = Threads.Atomic{Int}(0)  # tjlf_eigensolver call (amat/bmat fill + eigenvalue solve)
-const _PROBE_T_SOLVE    = Threads.Atomic{Int}(0)  # JUST the eigenvalue solve (_standard_eigenvalues_via_solve)
-const _PROBE_T_EIGVEC   = Threads.Atomic{Int}(0)  # eigenvector solve (whole block)
-const _PROBE_T_BSLASH   = Threads.Atomic{Int}(0)  # just the \ (or KrylovKit) inside the eigenvector block
-# which eigenvector branch was taken
-const _PROBE_N_INVITER  = Threads.Atomic{Int}(0)  # SMALL!=0 inverse-iteration (zmat \ rhs)
-const _PROBE_N_KRYLOV   = Threads.Atomic{Int}(0)  # SMALL==0 && (FIND_EIGEN||isnan) KrylovKit path
-const _PROBE_N_REUSE    = Threads.Atomic{Int}(0)  # SMALL==0 reuse v[:,jmax]
-
-function reset_probe!()
-    _PROBE_EIGVAL[] = 0
-    _PROBE_SZSUM[]  = 0
-    _PROBE_SZMAX[]  = 0
-    _PROBE_EIGVEC[] = 0
-    _PROBE_CAP[]    = nothing
-    _PROBE_T_GETMAT[]   = 0
-    _PROBE_T_EIGSOLVE[] = 0
-    _PROBE_T_SOLVE[]    = 0
-    _PROBE_T_EIGVEC[]   = 0
-    _PROBE_T_BSLASH[]   = 0
-    _PROBE_N_INVITER[]  = 0
-    _PROBE_N_KRYLOV[]   = 0
-    _PROBE_N_REUSE[]    = 0
-    return nothing
-end
-
-probe_stats() = (eigval_solves = _PROBE_EIGVAL[],
-                 size_sum      = _PROBE_SZSUM[],
-                 size_max      = _PROBE_SZMAX[],
-                 eigvec_solves = _PROBE_EIGVEC[],
-                 t_getmat_s    = _PROBE_T_GETMAT[]   / 1e9,
-                 t_eigsolve_s  = _PROBE_T_EIGSOLVE[] / 1e9,
-                 t_solve_s     = _PROBE_T_SOLVE[]    / 1e9,
-                 t_eigvec_s    = _PROBE_T_EIGVEC[]   / 1e9,
-                 t_bslash_s    = _PROBE_T_BSLASH[]   / 1e9,
-                 n_inviter     = _PROBE_N_INVITER[],
-                 n_krylov      = _PROBE_N_KRYLOV[],
-                 n_reuse       = _PROBE_N_REUSE[],
-                 captured      = _PROBE_CAP[])
-
 """
     tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satParams::SaturationParameters{T},ave::Ave{T},aveH::AveH{T},aveWH::AveWH{T},aveKH::AveKH,aveG::AveG{T},aveWG::AveWG{T},aveKG::AveKG,aveGrad::AveGrad{T},aveGradB::AveGradB{T},nbasis::Int, ky::T,amat::Matrix{K},bmat::Matrix{K},ky_index::Int) where T<:Real where K<:Complex
 
@@ -2774,16 +2722,6 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
         end
     end
 
-    if PROBE[]
-        n = size(amat, 1)
-        Threads.atomic_add!(_PROBE_EIGVAL, 1)
-        Threads.atomic_add!(_PROBE_SZSUM, n)
-        Threads.atomic_max!(_PROBE_SZMAX, n)
-        if _PROBE_CAP[] === nothing
-            _PROBE_CAP[] = (copy(amat), copy(bmat))
-        end
-    end
-
     use_tm = inputs.USE_TRANSPORT_MODEL
     if !use_gpu
         if !use_tm
@@ -2796,13 +2734,9 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
             if inputs.IFLUX || find_eigenvector
                 amat_copy = copy(amat)
                 bmat_copy = copy(bmat)
-                _ts0 = PROBE[] ? time_ns() : UInt64(0)
                 alpha = _standard_eigenvalues_via_solve(amat_copy, bmat_copy; use_gpu=use_gpu)
-                PROBE[] && Threads.atomic_add!(_PROBE_T_SOLVE, Int(time_ns() - _ts0))
             else
-                _ts0 = PROBE[] ? time_ns() : UInt64(0)
                 alpha = _standard_eigenvalues_via_solve(amat, bmat; use_gpu=use_gpu)
-                PROBE[] && Threads.atomic_add!(_PROBE_T_SOLVE, Int(time_ns() - _ts0))
             end
             return alpha, fill(NaN*im,(1,1))
         end
@@ -2810,13 +2744,9 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
         if inputs.IFLUX || find_eigenvector
             amat_copy = copy(amat)
             bmat_copy = copy(bmat)
-            _ts0 = PROBE[] ? time_ns() : UInt64(0)
             alpha = _standard_eigenvalues_via_solve(amat_copy, bmat_copy; use_gpu=use_gpu)
-            PROBE[] && Threads.atomic_add!(_PROBE_T_SOLVE, Int(time_ns() - _ts0))
         else
-            _ts0 = PROBE[] ? time_ns() : UInt64(0)
             alpha = _standard_eigenvalues_via_solve(amat, bmat; use_gpu=use_gpu)
-            PROBE[] && Threads.atomic_add!(_PROBE_T_SOLVE, Int(time_ns() - _ts0))
         end
 
     else
@@ -2824,9 +2754,7 @@ function tjlf_eigensolver(inputs::InputTJLF{T},outputGeo::OutputGeometry{T},satP
         # non-transport-model path would otherwise run (its result is unused).
         amat_copy = copy(amat)
         bmat_copy = copy(bmat)
-        _ts0 = PROBE[] ? time_ns() : UInt64(0)
         alpha = _standard_eigenvalues_via_solve(amat_copy, bmat_copy; use_gpu=use_gpu)
-        PROBE[] && Threads.atomic_add!(_PROBE_T_SOLVE, Int(time_ns() - _ts0))
     end
 
     return alpha, fill(NaN*im,(1,1))

--- a/src/tjlf_modules.jl
+++ b/src/tjlf_modules.jl
@@ -203,130 +203,136 @@ Base.@kwdef mutable struct InputTGLF{T<:Real}
 end
 
 Base.@kwdef mutable struct InputTJLF{T<:Real}
-    UNITS::Union{String,Missing} = missing
+    # NOTE: fields are concretely typed (no Union{...,Missing}) for type stability.
+    # Every inputs.FIELD read in the hot eigensolver path must infer to a concrete
+    # type; a Union{Missing,...} here poisons inference across all of TJLF and forces
+    # heap-boxing of millions of scalars. Defaults are sentinels (NaN for floats,
+    # 0 for ints, false for bools, empty vectors) that construction always overwrites;
+    # checkInput() still guards "fully populated" via the NaN sentinel for floats.
+    UNITS::String = ""
 
-    USE_BPER::Union{Bool,Missing} = missing
-    USE_BPAR::Union{Bool,Missing} = missing
-    USE_MHD_RULE::Union{Bool,Missing} = missing
-    USE_BISECTION::Union{Bool,Missing} = missing
-    USE_INBOARD_DETRAPPED::Union{Bool,Missing} = missing
-    USE_AVE_ION_GRID::Union{Bool,Missing} = missing
-    NEW_EIKONAL::Union{Bool,Missing} = missing
-    FIND_WIDTH::Union{Bool,Missing} = missing
-    IFLUX::Union{Bool,Missing} = missing
-    ADIABATIC_ELEC::Union{Bool,Missing} = missing
+    USE_BPER::Bool = false
+    USE_BPAR::Bool = false
+    USE_MHD_RULE::Bool = false
+    USE_BISECTION::Bool = false
+    USE_INBOARD_DETRAPPED::Bool = false
+    USE_AVE_ION_GRID::Bool = false
+    NEW_EIKONAL::Bool = false
+    FIND_WIDTH::Bool = false
+    IFLUX::Bool = false
+    ADIABATIC_ELEC::Bool = false
 
-    SAT_RULE::Union{Int,Missing} = missing
-    NS::Union{Int,Missing} = missing
-    NMODES::Union{Int,Missing} = missing
-    NWIDTH::Union{Int,Missing} = missing
-    NBASIS_MAX::Union{Int,Missing} = missing
-    NBASIS_MIN::Union{Int,Missing} = missing
-    NXGRID::Union{Int,Missing} = missing
-    NKY::Union{Int,Missing} = missing
-    KYGRID_MODEL::Union{Int,Missing} = missing
-    XNU_MODEL::Union{Int,Missing} = missing
-    VPAR_MODEL::Union{Int,Missing} = missing
-    IBRANCH::Union{Int,Missing} = missing
+    SAT_RULE::Int = 0
+    NS::Int = 0
+    NMODES::Int = 0
+    NWIDTH::Int = 0
+    NBASIS_MAX::Int = 0
+    NBASIS_MIN::Int = 0
+    NXGRID::Int = 0
+    NKY::Int = 0
+    KYGRID_MODEL::Int = 0
+    XNU_MODEL::Int = 0
+    VPAR_MODEL::Int = 0
+    IBRANCH::Int = 0
 
-    ZS::Union{Vector{T},Missing} = missing
-    MASS::Union{Vector{T},Missing} = missing
-    RLNS::Union{Vector{T},Missing} = missing
-    RLTS::Union{Vector{T},Missing} = missing
-    TAUS::Union{Vector{T},Missing} = missing
-    AS::Union{Vector{T},Missing} = missing
-    VPAR::Union{Vector{T},Missing} = missing
-    VPAR_SHEAR::Union{Vector{T},Missing} = missing
+    ZS::Vector{T} = T[]
+    MASS::Vector{T} = T[]
+    RLNS::Vector{T} = T[]
+    RLTS::Vector{T} = T[]
+    TAUS::Vector{T} = T[]
+    AS::Vector{T} = T[]
+    VPAR::Vector{T} = T[]
+    VPAR_SHEAR::Vector{T} = T[]
 
     # NOT IN TGLF (or missing from InputTGLF structure)
-    WIDTH_SPECTRUM::Union{Vector{T},Missing} = missing    # TJLF-specific
-    KY_SPECTRUM::Union{Vector{T},Missing} = missing       # TJLF-specific  
-    EIGEN_SPECTRUM::Union{Vector{Complex{T}},Missing} = missing  # TJLF-specific
-    FIND_EIGEN::Union{Bool,Missing} = missing             # TGLF parameter but missing from InputTGLF
+    WIDTH_SPECTRUM::Vector{T} = T[]    # TJLF-specific
+    KY_SPECTRUM::Vector{T} = T[]       # TJLF-specific  
+    EIGEN_SPECTRUM::Vector{Complex{T}} = Complex{T}[]  # TJLF-specific
+    FIND_EIGEN::Bool = true             # TGLF parameter but missing from InputTGLF
     # NOT IN TGLF (or missing from InputTGLF structure)
 
-    SIGN_BT::Union{Int,Missing} = missing
-    SIGN_IT::Union{Int,Missing} = missing
-    KY::Union{T,Missing} = missing
+    SIGN_BT::Int = 0
+    SIGN_IT::Int = 0
+    KY::T = T(NaN)
 
-    VEXB_SHEAR::Union{T,Missing} = missing
-    BETAE::Union{T,Missing} = missing
-    XNUE::Union{T,Missing} = missing
-    ZEFF::Union{T,Missing} = missing
-    DEBYE::Union{T,Missing} = missing
+    VEXB_SHEAR::T = T(NaN)
+    BETAE::T = T(NaN)
+    XNUE::T = T(NaN)
+    ZEFF::T = T(NaN)
+    DEBYE::T = T(NaN)
 
-    ALPHA_MACH::Union{T,Missing} = missing
-    ALPHA_E::Union{T,Missing} = missing
-    ALPHA_P::Union{T,Missing} = missing
-    ALPHA_QUENCH::Union{Int,Missing} = missing
-    ALPHA_ZF::Union{T,Missing} = missing
-    XNU_FACTOR::Union{T,Missing} = missing
-    DEBYE_FACTOR::Union{T,Missing} = missing
-    ETG_FACTOR::Union{T,Missing} = missing
-    RLNP_CUTOFF::Union{T,Missing} = missing
+    ALPHA_MACH::T = T(NaN)
+    ALPHA_E::T = T(NaN)
+    ALPHA_P::T = T(NaN)
+    ALPHA_QUENCH::Int = 0
+    ALPHA_ZF::T = T(NaN)
+    XNU_FACTOR::T = T(NaN)
+    DEBYE_FACTOR::T = T(NaN)
+    ETG_FACTOR::T = T(NaN)
+    RLNP_CUTOFF::T = T(NaN)
 
-    WIDTH::Union{T,Missing} = missing
-    WIDTH_MIN::Union{T,Missing} = missing
+    WIDTH::T = T(NaN)
+    WIDTH_MIN::T = T(NaN)
 
-    RMIN_LOC::Union{T,Missing} = missing
-    RMAJ_LOC::Union{T,Missing} = missing
-    ZMAJ_LOC::Union{T,Missing} = missing
-    DRMINDX_LOC::Union{T,Missing} = missing
-    DRMAJDX_LOC::Union{T,Missing} = missing
-    DZMAJDX_LOC::Union{T,Missing} = missing
-    Q_LOC::Union{T,Missing} = missing
-    KAPPA_LOC::Union{T,Missing} = missing
-    S_KAPPA_LOC::Union{T,Missing} = missing
-    DELTA_LOC::Union{T,Missing} = missing
-    S_DELTA_LOC::Union{T,Missing} = missing
-    ZETA_LOC::Union{T,Missing} = missing
-    S_ZETA_LOC::Union{T,Missing} = missing
-    P_PRIME_LOC::Union{T,Missing} = missing
-    Q_PRIME_LOC::Union{T,Missing} = missing
-    BETA_LOC::Union{T,Missing} = missing
-    KX0_LOC::Union{T,Missing} = missing
+    RMIN_LOC::T = T(NaN)
+    RMAJ_LOC::T = T(NaN)
+    ZMAJ_LOC::T = T(NaN)
+    DRMINDX_LOC::T = T(NaN)
+    DRMAJDX_LOC::T = T(NaN)
+    DZMAJDX_LOC::T = T(NaN)
+    Q_LOC::T = T(NaN)
+    KAPPA_LOC::T = T(NaN)
+    S_KAPPA_LOC::T = T(NaN)
+    DELTA_LOC::T = T(NaN)
+    S_DELTA_LOC::T = T(NaN)
+    ZETA_LOC::T = T(NaN)
+    S_ZETA_LOC::T = T(NaN)
+    P_PRIME_LOC::T = T(NaN)
+    Q_PRIME_LOC::T = T(NaN)
+    BETA_LOC::T = T(NaN)
+    KX0_LOC::T = T(NaN)
 
-    DAMP_PSI::Union{T,Missing} = missing
-    DAMP_SIG::Union{T,Missing} = missing
-    WDIA_TRAPPED::Union{T,Missing} = missing
-    PARK::Union{T,Missing} = missing
-    GHAT::Union{T,Missing} = missing
-    GCHAT::Union{T,Missing} = missing
-    WD_ZERO::Union{T,Missing} = missing
-    LINSKER_FACTOR::Union{T,Missing} = missing
-    GRADB_FACTOR::Union{T,Missing} = missing
-    FILTER::Union{T,Missing} = missing
-    THETA_TRAPPED::Union{T,Missing} = missing
-    SMALL::Union{T,Missing} = missing
+    DAMP_PSI::T = T(NaN)
+    DAMP_SIG::T = T(NaN)
+    WDIA_TRAPPED::T = T(NaN)
+    PARK::T = T(NaN)
+    GHAT::T = T(NaN)
+    GCHAT::T = T(NaN)
+    WD_ZERO::T = T(NaN)
+    LINSKER_FACTOR::T = T(NaN)
+    GRADB_FACTOR::T = T(NaN)
+    FILTER::T = T(NaN)
+    THETA_TRAPPED::T = T(NaN)
+    SMALL::T = T(NaN)
 
-    #MXH params
-    SHAPE_COS0::Union{T,Missing} = missing
-    SHAPE_COS1::Union{T,Missing} = missing
-    SHAPE_COS2::Union{T,Missing} = missing
-    SHAPE_COS3::Union{T,Missing} = missing
-    SHAPE_COS4::Union{T,Missing} = missing
-    SHAPE_COS5::Union{T,Missing} = missing
-    SHAPE_COS6::Union{T,Missing} = missing
+    #MXH params (optional; default to 0 so checkInput passes when unset by geometry)
+    SHAPE_COS0::T = zero(T)
+    SHAPE_COS1::T = zero(T)
+    SHAPE_COS2::T = zero(T)
+    SHAPE_COS3::T = zero(T)
+    SHAPE_COS4::T = zero(T)
+    SHAPE_COS5::T = zero(T)
+    SHAPE_COS6::T = zero(T)
 
-    SHAPE_SIN3::Union{T,Missing} = missing
-    SHAPE_SIN4::Union{T,Missing} = missing
-    SHAPE_SIN5::Union{T,Missing} = missing
-    SHAPE_SIN6::Union{T,Missing} = missing
+    SHAPE_SIN3::T = zero(T)
+    SHAPE_SIN4::T = zero(T)
+    SHAPE_SIN5::T = zero(T)
+    SHAPE_SIN6::T = zero(T)
 
-    SHAPE_S_COS0::Union{T,Missing} = missing
-    SHAPE_S_COS1::Union{T,Missing} = missing
-    SHAPE_S_COS2::Union{T,Missing} = missing
-    SHAPE_S_COS3::Union{T,Missing} = missing
-    SHAPE_S_COS4::Union{T,Missing} = missing
-    SHAPE_S_COS5::Union{T,Missing} = missing
-    SHAPE_S_COS6::Union{T,Missing} = missing
+    SHAPE_S_COS0::T = zero(T)
+    SHAPE_S_COS1::T = zero(T)
+    SHAPE_S_COS2::T = zero(T)
+    SHAPE_S_COS3::T = zero(T)
+    SHAPE_S_COS4::T = zero(T)
+    SHAPE_S_COS5::T = zero(T)
+    SHAPE_S_COS6::T = zero(T)
 
-    SHAPE_S_SIN3::Union{T,Missing} = missing
-    SHAPE_S_SIN4::Union{T,Missing} = missing
-    SHAPE_S_SIN5::Union{T,Missing} = missing
-    SHAPE_S_SIN6::Union{T,Missing} = missing
+    SHAPE_S_SIN3::T = zero(T)
+    SHAPE_S_SIN4::T = zero(T)
+    SHAPE_S_SIN5::T = zero(T)
+    SHAPE_S_SIN6::T = zero(T)
 
-    USE_TRANSPORT_MODEL::Union{Bool,Missing} = missing
+    USE_TRANSPORT_MODEL::Bool = true
 end
 
 function InputTJLF{T}(ns::Int, nky::Int) where {T<:Real}
@@ -438,7 +444,10 @@ function update_input_tjlf!(input_tjlf::InputTJLF{T}, input_tglf::InputTGLF{T}) 
     input_tjlf.NWIDTH = 21
 
     for fieldname in intersect(fieldnames(typeof(input_tglf)), fieldnames(typeof(input_tjlf)))
-        setfield!(input_tjlf, fieldname, getfield(input_tglf, fieldname))
+        v = getfield(input_tglf, fieldname)
+        # InputTJLF fields are now concrete (no Missing); skip unset source fields so
+        # the concrete sentinel default stands (checkInput still guards true "unset").
+        ismissing(v) || setfield!(input_tjlf, fieldname, v)
     end
 
     for i in 1:input_tglf.NS

--- a/src/tjlf_read_input.jl
+++ b/src/tjlf_read_input.jl
@@ -154,19 +154,16 @@ function readInput(filename::String)::InputTJLF
     end
 
     inputTJLF.WIDTH_SPECTRUM .= inputTJLF.WIDTH
-    if ismissing(inputTJLF.KY_SPECTRUM)
-        inputTJLF.KY_SPECTRUM .= NaN 
+    # KY_SPECTRUM/EIGEN_SPECTRUM are NaN-filled by the (ns,nky) constructor; if a caller
+    # constructed via @kwdef defaults they are empty, in which case nothing to fill.
+    if isempty(inputTJLF.KY_SPECTRUM)
+        inputTJLF.KY_SPECTRUM = fill(NaN, length(inputTJLF.WIDTH_SPECTRUM))
     end
-    if ismissing(inputTJLF.EIGEN_SPECTRUM)
-        inputTJLF.EIGEN_SPECTRUM .= NaN 
+    if isempty(inputTJLF.EIGEN_SPECTRUM)
+        inputTJLF.EIGEN_SPECTRUM = fill(ComplexF64(NaN), length(inputTJLF.WIDTH_SPECTRUM))
     end
-    
 
-    # double check struct is properly populated
-
-    if ismissing(inputTJLF.FIND_EIGEN)
-        inputTJLF.FIND_EIGEN = true
-    end
+    # double check struct is properly populated (FIND_EIGEN is a concrete Bool, default true)
 
     #Maybe checkInput could be altered for inputting default values, or the struct in modules could be
     #Redefined as having 


### PR DESCRIPTION
# Multi-GPU acceleration, unified CPU eigensolve, Type-stable inputs + AD

This PR builds on the GPU eigensolver foundation merged in v1.2.4. It makes
`InputTJLF` type-stable (unlocking ForwardDiff-based AD), unifies the CPU
eigenvalue/eigenvector solves, and extends the GPU path to multiple devices and
to the eigenvector solve. All changes preserve the published TGLF results
(regression suite `tglf01`–`tglf11` green; TJLFEP nb6 SFmin matches Fortran to
`rel_err ≈ 6.8e-6`).

## Motivation

Two goals drove this work:

1. **Differentiability** — make `TJLF.run` traceable by ForwardDiff so growth
   rates / fluxes can be differentiated w.r.t. inputs.
2. **Performance** — close the gap with (and on GPU, beat) Fortran TGLF-EP for
   large scans, where the per-radius cost is dominated by many small/medium
   dense complex eigensolves.

## Changes

### 1. Type-stable `InputTJLF` (enables AD)

All 106 `InputTJLF` fields were `Union{X,Missing} = missing`, so every
`inputs.FIELD` read inferred as `Union{Missing,X}` — poisoning inference through
the eigensolver and forcing heap-boxing of scalars.

- Fields are now **concrete** with sentinel defaults (`T(NaN)` floats, `0` ints,
  `false` bools except `FIND_EIGEN`/`USE_TRANSPORT_MODEL=true`, empty vectors).
- **Field names and order are unchanged (still 106)**, so name-based
  `setfield!` / intersect-copy paths are unaffected.
- `readInput`: `ismissing` → `isempty` for `KY_SPECTRUM`/`EIGEN_SPECTRUM`;
  `checkInput`'s `!isnan` assert now enforces "fully populated" via the NaN
  sentinel.
- `update_input_tjlf!`: the `InputTGLF`→`InputTJLF` copy is guarded with
  `ismissing(v) ||` so a stray `missing` source field no longer throws on the
  concrete target.

**Impact:** `test_EM` allocations 755.9 → 340.7 MiB; `TJLF.run` checksums
bit-identical before/after; `T=Dual` now flows cleanly for ForwardDiff.

### 2. Unified CPU eigensolve

- **Scoped BLAS threads.** The previous top-level `BLAS.set_num_threads(1)` only
  ran at *precompile* time (thread count is runtime state, not serialized into
  the cache), so at load BLAS sat at its default (e.g. 128). With `ky`
  parallelized over Julia threads doing small dense LAPACK solves, that
  oversubscribed cores and inflated per-solve time ~100×. A scoped
  `with_blas_threads(f, n)` helper (restores the prior count; race-free nested
  scopes) is applied around `run` / `run_tjlf`, **without** imposing a global
  BLAS default on host apps like FUSE. → ~4× per nb6 radius (183 s → 44 s).
- **`gesv!`+`geev!` for the non-transport CPU path.** It previously used the
  generalized `ggev!`, while the transport and GPU paths use the standard solve
  `B⁻¹A` (`gesv!` then `geev!`). For these well-conditioned pencils the two agree
  to ~1e-11 relative, but `gesv!`+`geev!` is ~4× faster on the small dense
  matrices (270×270: 179 ms → 45 ms). → nb6 radius 42.6 s → 10.9 s.
- **In-place inverse-iteration eigenvector:** `ldiv!(lu!(zmat), v)` instead of
  `zmat \ v`, dropping a ~2.24 MiB/solve matrix copy (mathematically identical).

### 3. Multi-GPU + GPU eigenvector solve

Building on the GPU eigenvalue solve (CUSOLVER `Xgeev`) from v1.2.4:

- **Per-device locks + round-robin.** The single global GPU solve lock is
  replaced with one lock per device plus an atomic round-robin counter, so a
  radius's ~1k dense eigensolves spread across all visible GPUs and run
  concurrently. → nb32 (1440×1440): 1 GPU 359 s/radius → 2 GPUs 211 s/radius
  (1.70×), SFmin bit-identical. Fully backward-compatible: with one visible GPU
  this reduces to the prior single-lock behavior.
- **GPU eigenvector solve.** The `SMALL≠0` inverse-iteration step
  `(amat − σ·bmat) x = b` was a host `lu!`/`ldiv!` of the full `iur×iur` complex
  matrix; under `BLAS=1` this single-threaded LU saturated node memory bandwidth
  alongside assembly. A TJLF-owned `_gpu_lu_solve!` hook (CUSOLVER `getrf`/`getrs`
  in `TJLFCUDAExt`, same device round-robin + per-device lock as the eigenvalue
  solve) now runs it on the GPU when `use_gpu && eltype===ComplexF64`; it falls
  back to the CPU path for AD/`Dual` types or when CUDA is unavailable.
  → nb32 single radius: `:threads` 214 s → 116 s (1.85×); `:mps_team` (4 GPUs,
  16w×4t) 123 s → 35 s (3.55×); SFmin bit-exact `0.6249450209778226`.

## Correctness / testing

- CPU regression suite `tglf01`–`tglf11`: all pass.
- TJLFEP nb6 single-radius SFmin matches Fortran (`rel_err ≈ 6.8e-6`); `TJLF.run`
  checksums bit-identical across the type-stability change.
- GPU paths validated SFmin bit-exact against the CPU/Fortran reference
  (`0.624945…`) for nb6 and nb32, including the full 20-radius TGLF-EP scan.

## Compatibility notes

- **`InputTJLF` fields are now concrete** (no longer `Union{T,Missing}`); a field
  can no longer be assigned `missing`. The standard construction paths are
  unaffected: `readInput`, `InputTJLF{T}(ns, nky)`, and `InputTJLF{T}(input_tglf)`
  (the latter via `update_input_tjlf!`, which skips `missing` source fields so a
  partially-populated `InputTGLF` still converts). `InputTGLF`/`InputCGYRO` are
  unchanged, so FUSE/TurbulentTransport's `InputTGLF`-based flow and all their
  `ismissing` handling continue to work. The only behavioral change: defensive
  "field is Missing" checks that read an `InputTJLF` field no longer fire — an
  unset field now reads as its sentinel (`NaN`) rather than `missing`, so a
  malformed/incomplete input surfaces as NaN-propagation instead of an explicit
  error (the normal fully-populated flow is unaffected).
- **No global BLAS default** is set by TJLF; threading is scoped to the compute
  drivers only.
- **GPU is opt-in** (`use_gpu=true`) and requires CUDA ≥ 12.6 (for
  `cusolverDnXgeev`); the default CPU path is unchanged when CUDA is absent.
