### PR TITLE
AD: fast Float64-LAPACK path for the standard eigenvalue solve

### DIFF
--- a/ext/TJLFForwardDiffExt.jl
+++ b/ext/TJLFForwardDiffExt.jl
@@ -241,4 +241,61 @@ function TJLF._generalized_eigenvalues(A::Matrix{Complex{D}}, B::Matrix{Complex{
     end
 end
 
+# ── Fast eigenvalues-only path for the standard solve B⁻¹A (Dual entries) ────
+# The EP single-ky / non-transport path needs ONLY the eigenvalues (and their
+# derivatives), so it calls `_standard_eigenvalues_via_solve`, whose generic
+# fallback is `_herm_eigen(B \ A).values`. That fallback is very slow on Dual
+# inputs because BOTH `B \ A` and the second `eigen(A')` run in generic (non-
+# BLAS) Complex{Dual} arithmetic.
+#
+# This specialization keeps every O(n³) kernel in Float64 LAPACK/BLAS:
+#   1. M = B⁻¹A and its partials via ONE LU of Bf (reused):  ∂M = B⁻¹(∂A − ∂B·M)
+#   2. eigenvalues + right vectors R of Mf via geev (LAPACK)
+#   3. left vectors from R⁻¹ (one LU of R) — no second eigendecomposition
+#   4. ∂λᵢ = (R⁻¹ ∂M R)[i,i]                                  (standard problem)
+# Returns ONLY eigenvalues (Vector{Complex{Dual}}), matching the Float64 method.
+function TJLF._standard_eigenvalues_via_solve(A::Matrix{Complex{D}}, B::Matrix{Complex{D}};
+                                              use_gpu::Bool = false) where {D <: ForwardDiff.Dual}
+    np  = ForwardDiff.npartials(D)
+    Tag = ForwardDiff.tagtype(D)
+    n   = size(A, 1)
+
+    cval(x)    = Complex{Float64}(ForwardDiff.value(real(x)), ForwardDiff.value(imag(x)))
+    cpar(x, k) = Complex{Float64}(ForwardDiff.partials(real(x), k), ForwardDiff.partials(imag(x), k))
+
+    Af = map(cval, A)
+    Bf = map(cval, B)
+
+    # M = B⁻¹A and ∂M = B⁻¹(∂A − ∂B·M), all sharing one LAPACK LU of Bf.
+    luB = lu(Bf)
+    Mf  = luB \ Af
+    dM  = Vector{Matrix{Complex{Float64}}}(undef, np)
+    for k in 1:np
+        dAk = map(x -> cpar(x, k), A)
+        dBk = map(x -> cpar(x, k), B)
+        dM[k] = luB \ (dAk .- dBk * Mf)
+    end
+
+    # Eigenvalues + right eigenvectors of the standard problem Mf r = λ r.
+    F  = eigen(Mf)
+    λf = F.values
+    R  = F.vectors
+    luR = lu(R)                       # left vectors lᵢᴴ = row i of R⁻¹ (lᵢᴴ rⱼ = δᵢⱼ)
+
+    dλ_re = zeros(n, np)
+    dλ_im = zeros(n, np)
+    for k in 1:np
+        C = luR \ (dM[k] * R)         # = R⁻¹ ∂M R, all Float64 BLAS
+        for i in 1:n
+            dλ_re[i, k] = real(C[i, i])
+            dλ_im[i, k] = imag(C[i, i])
+        end
+    end
+
+    return map(1:n) do i
+        Complex(ForwardDiff.Dual{Tag}(real(λf[i]), ntuple(k -> dλ_re[i, k], Val(np))...),
+                ForwardDiff.Dual{Tag}(imag(λf[i]), ntuple(k -> dλ_im[i, k], Val(np))...))
+    end
+end
+
 end


### PR DESCRIPTION
Add a ForwardDiff.Dual specialization of _standard_eigenvalues_via_solve so the TJLFEP single-ky AD path (B⁻¹A eigenvalues) keeps every O(n³) kernel in Float64 LAPACK/BLAS instead of generic Dual arithmetic:

  - one LU of Bf, reused for M = B⁻¹A and its partials (∂M = B⁻¹(∂A − ∂B·M))
  - eigenvalues + right vectors of Mf via geev; left vectors from R⁻¹ (no second eigendecomposition)
  - ∂λᵢ = (R⁻¹ ∂M R)[i,i]

Eigenvalue derivatives are unchanged (match finite differences to ~1e-9); the per-solve Dual overhead at nb=32 drops from ~29× to ~15× (the remaining cost was the unused QL/eigenvector block, disabled on the TJLFEP side).