### PR TITLE
(ci): add CODECOV_TOKEN to CI

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:
@@ -50,3 +51,4 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![codecov](https://codecov.io/github/ProjectTorreyPines/TJLF.jl/graph/badge.svg?token=1NY1YYLBWH)](https://codecov.io/github/ProjectTorreyPines/TJLF.jl)
+
 # TJLF
 Tglf in Julia Learned from Fortran (TJLF)
 


### PR DESCRIPTION
## Summary
Pass org-level `CODECOV_TOKEN` to codecov-action and add `workflow_dispatch` trigger
