### PR TITLE
Autodiff on GPU

### DIFF
--- a/ext/TJLFCUDAExt.jl
+++ b/ext/TJLFCUDAExt.jl
@@ -77,6 +77,55 @@ function __init__()
             return vec(Array(x_gpu))
         end
     end
+
+    # Complex{Dual} eigensolve: eigenvalues of M=B⁻¹A plus IFT derivatives ∂λᵢ for each
+    # partial. Mirrors the CPU Dual kernel (TJLFForwardDiffExt) but keeps every O(n³) step
+    # on the GPU: getrf/getrs for M and ∂M (one LU of B reused), Xgeev('N','V') for the
+    # eigenpairs, then ∂λᵢ=(R⁻¹∂M R)[i,i]. Round-robin device + per-device lock match
+    # _CUDA_SOLVE so team workers overlap across GPUs via MPS while staying serialized
+    # within a CUDA context (Xgeev is not concurrency-safe intra-context).
+    TJLF._CUDA_SOLVE_EIG_GRAD[] = (A::Matrix{ComplexF64}, B::Matrix{ComplexF64},
+                                   dA::Vector{Matrix{ComplexF64}}, dB::Vector{Matrix{ComplexF64}}) -> begin
+        devs = _devices()
+        ndev = length(devs)
+        dev = devs[mod1(Threads.atomic_add!(_GPU_RR, 1) + 1, ndev)]
+        CUDA.device!(dev)
+        lock(_device_lock(CUDA.deviceid(dev))) do
+            np = length(dA)
+            m  = size(A, 1)
+            A_gpu = CUDA.CuArray(A)
+            B_gpu = CUDA.CuArray(B)
+            ipivB = CUDA.CuArray{Int32}(undef, m)
+            B_fact, ipivB, _ = CUDA.CUSOLVER.getrf!(B_gpu, ipivB)
+            # Mf = B⁻¹A (getrs! overwrites A_gpu and returns it).
+            Mf = CUDA.CUSOLVER.getrs!('N', B_fact, ipivB, A_gpu)
+            # ∂M[k] = B⁻¹(∂A[k] − ∂B[k]·Mf), reusing the LU of B. Done BEFORE Xgeev overwrites Mf.
+            dMs = Vector{CUDA.CuMatrix{ComplexF64}}(undef, np)
+            for k in 1:np
+                dAk = CUDA.CuArray(dA[k])
+                dBk = CUDA.CuArray(dB[k])
+                rhs = dAk - dBk * Mf
+                dMs[k] = CUDA.CUSOLVER.getrs!('N', B_fact, ipivB, rhs)
+            end
+            # Eigenpairs of Mf: eigenvalues W + right vectors VR (Xgeev! overwrites Mf).
+            W, _, VR = CUDA.CUSOLVER.Xgeev!('N', 'V', Mf)
+            # Factor a COPY of VR (getrf! is in-place); keep VR itself for the ∂M·R product.
+            VRf = copy(VR)
+            ipivR = CUDA.CuArray{Int32}(undef, m)
+            VRf, ipivR, _ = CUDA.CUSOLVER.getrf!(VRf, ipivR)
+            dλ_re = zeros(Float64, m, np)
+            dλ_im = zeros(Float64, m, np)
+            for k in 1:np
+                C  = CUDA.CUSOLVER.getrs!('N', VRf, ipivR, dMs[k] * VR)  # = R⁻¹ ∂M R
+                Ch = Array(C)
+                @inbounds for i in 1:m
+                    dλ_re[i, k] = real(Ch[i, i])
+                    dλ_im[i, k] = imag(Ch[i, i])
+                end
+            end
+            return (Array(W), dλ_re, dλ_im)
+        end
+    end
 end
 
 end

--- a/ext/TJLFForwardDiffExt.jl
+++ b/ext/TJLFForwardDiffExt.jl
@@ -266,6 +266,22 @@ function TJLF._standard_eigenvalues_via_solve(A::Matrix{Complex{D}}, B::Matrix{C
     Af = map(cval, A)
     Bf = map(cval, B)
 
+    # GPU path: do the whole Dual eigensolve+IFT on the device (CUSOLVER), mirroring the
+    # CPU kernel below. Only taken when CUDA is loaded+functional; falls back otherwise.
+    if use_gpu && TJLF._cuda_functional()
+        dA = Vector{Matrix{Complex{Float64}}}(undef, np)
+        dB = Vector{Matrix{Complex{Float64}}}(undef, np)
+        for k in 1:np
+            dA[k] = map(x -> cpar(x, k), A)
+            dB[k] = map(x -> cpar(x, k), B)
+        end
+        W, dλ_re, dλ_im = TJLF._gpu_solve_eig_grad!(Af, Bf, dA, dB)
+        return map(1:n) do i
+            Complex(ForwardDiff.Dual{Tag}(real(W[i]), ntuple(k -> dλ_re[i, k], Val(np))...),
+                    ForwardDiff.Dual{Tag}(imag(W[i]), ntuple(k -> dλ_im[i, k], Val(np))...))
+        end
+    end
+
     # M = B⁻¹A and ∂M = B⁻¹(∂A − ∂B·M), all sharing one LAPACK LU of Bf.
     luB = lu(Bf)
     Mf  = luB \ Af

--- a/src/TJLF.jl
+++ b/src/TJLF.jl
@@ -15,6 +15,7 @@ const _CUDA_FUNCTIONAL = Ref{Any}(() -> false)
 const _CUDA_DEVICE_COUNT = Ref{Any}(() -> 0)
 const _CUDA_SOLVE = Ref{Any}(nothing)
 const _CUDA_LU_SOLVE = Ref{Any}(nothing)
+const _CUDA_SOLVE_EIG_GRAD = Ref{Any}(nothing)
 
 # wrappers so call sites stay the same
 _cuda_functional() = _CUDA_FUNCTIONAL[]()
@@ -31,6 +32,20 @@ end
 function _gpu_lu_solve!(Z::Matrix{ComplexF64}, b::Vector{ComplexF64})
     _CUDA_LU_SOLVE[] === nothing && error("CUDA extension not loaded")
     return _CUDA_LU_SOLVE[](Z, b)
+end
+
+# GPU eigenvalues + implicit-function-theorem derivatives for the standard problem
+# M = B⁻¹A (ForwardDiff.Dual support). Given the value matrices `A,B` and the per-partial
+# matrices `dA[k]=∂A/∂xₖ`, `dB[k]=∂B/∂xₖ` (all host ComplexF64), this mirrors the CPU Dual
+# kernel entirely on the GPU (CUSOLVER getrf/getrs for M and ∂M, Xgeev('N','V') for the
+# eigenpairs, then ∂λᵢ = (R⁻¹ ∂M R)[i,i]). Returns
+# `(W::Vector{ComplexF64}, dλ_re::Matrix{Float64}(n,np), dλ_im::Matrix{Float64}(n,np))`.
+# The IFT diagonal R⁻¹∂M R is invariant to eigenvector column scaling, so CUSOLVER-vs-LAPACK
+# normalization differences are harmless.
+function _gpu_solve_eig_grad!(A::Matrix{ComplexF64}, B::Matrix{ComplexF64},
+                              dA::Vector{Matrix{ComplexF64}}, dB::Vector{Matrix{ComplexF64}})
+    _CUDA_SOLVE_EIG_GRAD[] === nothing && error("CUDA extension not loaded")
+    return _CUDA_SOLVE_EIG_GRAD[](A, B, dA, dB)
 end
 
 # @show BLAS.get_config()


### PR DESCRIPTION
## Summary
Adds a GPU eigensolve+gradient kernel so the forward-mode-AD (`ForwardDiff.Dual`)
eigenvalue solves used by TGLF-EP's autodiff critical-factor path can run on the
GPU instead of CPU-only.

## What changed
- **`src/TJLF.jl`** — new `_CUDA_SOLVE_EIG_GRAD` hook + `_gpu_solve_eig_grad!`
  dispatcher (errors if the CUDA extension is not loaded).
- **`ext/TJLFCUDAExt.jl`** — CUSOLVER kernel computing the eigenvalues of
  `M = B⁻¹A` **and** their implicit-function-theorem derivatives entirely on the
  GPU: `getrf`/`getrs` for `M` and each `∂M`, `Xgeev('N','V')` for the eigenpairs,
  then `∂λᵢ = (R⁻¹ ∂M R)ᵢᵢ`. Mirrors the existing `_CUDA_SOLVE` device handling
  (round-robin device + per-device lock) so it composes with the production
  MPS-team route.
- **`ext/TJLFForwardDiffExt.jl`** — `use_gpu` branch in
  `_standard_eigenvalues_via_solve(::Matrix{Complex{Dual}})`; the CPU LAPACK
  path is preserved as the fallback when CUDA is unavailable.

## Validation
GPU `Dual` derivatives match the CPU `Dual` path to ~1e-10 and match central
finite differences at `N_BASIS=32` (DIII-D verification case). The IFT diagonal
`R⁻¹ ∂M R` is invariant to eigenvector column scaling, so CUSOLVER-vs-LAPACK
normalization differences are harmless.

## Compatibility
No API change; CPU behavior is unchanged. The new path is only taken when
`use_gpu=true` and a functional CUDA runtime (>= 12.6, for `cusolverDnXgeev`) is
present.
